### PR TITLE
修正安装 MySQL 5.7 时，boost版本需要1.59.0的问题 

### DIFF
--- a/function/config.sh
+++ b/function/config.sh
@@ -182,11 +182,11 @@ https://www.php.net/distributions/php-7.3.5.tar.gz
 '
 
 #libzip设置
-libzip_filename="libzip-1.5.2"
+libzip_filename="libzip-1.2.0"
 set_md5 $libzip_filename "8db7145801889ecf7ab481b23d6487cd"
 set_dl $libzip_filename '
-https://opensource-1251020419.file.myqcloud.com/libzip/libzip-1.5.2.tar.gz
-https://libzip.org/download/libzip-1.5.2.tar.gz
+https://opensource-1251020419.file.myqcloud.com/libzip/libzip-1.2.0.tar.gz
+https://libzip.org/download/libzip-1.2.0.tar.gz
 '
 
 #freetds设置

--- a/function/config.sh
+++ b/function/config.sh
@@ -13,6 +13,7 @@ allow_seconds=3600
 nginx_filename="nginx-1.14.2"
 set_md5 $nginx_filename "239b829a13cea1d244c1044e830bd9c2"
 set_dl $nginx_filename '
+https://opensource-1251020419.file.myqcloud.com/nginx/nginx-1.14.2.tar.gz
 http://nginx.org/download/nginx-1.14.2.tar.gz
 '
 
@@ -101,6 +102,7 @@ http://mirrors.ustc.edu.cn/mysql-ftp/Downloads/MySQL-8.0/mysql-8.0.16.tar.gz
 boost_1_59_filename="boost_1_59_0"
 set_md5 $boost_1_59_filename "51528a0e3b33d9e10aaa311d9eb451e3"
 set_dl $boost_1_59_filename '
+https://opensource-1251020419.file.myqcloud.com/boost/boost_1_59_0.tar.gz
 https://nchc.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz
 https://jaist.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz
 http://sourceforge.mirrorservice.org/b/bo/boost/boost/1.59.0/boost_1_59_0.tar.gz
@@ -109,7 +111,7 @@ http://sourceforge.mirrorservice.org/b/bo/boost/boost/1.59.0/boost_1_59_0.tar.gz
 boost_1_66_filename="boost_1_66_0"
 set_md5 $boost_1_66_filename "d275cd85b00022313c171f602db59fc5"
 set_dl $boost_1_66_filename '
-http://dl-cn.centos.bz/protect/10268950/ezhttp/boost_1_66_0.tar.gz
+https://opensource-1251020419.file.myqcloud.com/boost/boost_1_66_0.tar.gz
 https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
 http://dl-us.centos.bz/ezhttp/boost_1_66_0.tar.gz
 http://jaist.dl.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.gz
@@ -157,24 +159,34 @@ http://dl-us.centos.bz/ezhttp/php-5.6.15.tar.gz
 http://us1.php.net/distributions/php-5.6.15.tar.gz
 '
 
-php7_1_filename="php-7.1.0"
-set_md5 $php7_1_filename "ec2218f97b4edbc35a2d7919ff37a662"
+php7_1_filename="php-7.1.29"
+set_md5 $php7_1_filename "71a43101a0f44d409851d7f62f10a030"
 set_dl $php7_1_filename '
-http://dl-cn.centos.bz/protect/10268950/ezhttp/php-7.1.0.tar.gz
-http://dl-us.centos.bz/ezhttp/php-7.1.0.tar.gz
-http://us1.php.net/distributions/php-7.1.0.tar.gz
+https://opensource-1251020419.file.myqcloud.com/php/php-7.1.29.tar.gz
+http://dl-us.centos.bz/ezhttp/php-7.1.29.tar.gz
+https://www.php.net/distributions/php-7.1.29.tar.gz
 '
 
 php7_2_filename="php-7.2.18"
 set_md5 $php7_2_filename "30333c28bbbbcc296cb80c0a9b059356"
 set_dl $php7_2_filename '
+https://opensource-1251020419.file.myqcloud.com/php/php-7.2.18.tar.gz
 https://www.php.net/distributions/php-7.2.18.tar.gz
 '
 
 php7_3_filename="php-7.3.5"
 set_md5 $php7_3_filename "8cca50c78c38ff2c92f9aa65a9c3894b"
 set_dl $php7_3_filename '
+https://opensource-1251020419.file.myqcloud.com/php/php-7.3.5.tar.gz
 https://www.php.net/distributions/php-7.3.5.tar.gz
+'
+
+#libzip设置
+libzip_filename="libzip-1.5.2"
+set_md5 $libzip_filename "8db7145801889ecf7ab481b23d6487cd"
+set_dl $libzip_filename '
+https://opensource-1251020419.file.myqcloud.com/libzip/libzip-1.5.2.tar.gz
+https://libzip.org/download/libzip-1.5.2.tar.gz
 '
 
 #freetds设置

--- a/function/config.sh
+++ b/function/config.sh
@@ -14,7 +14,6 @@ nginx_filename="nginx-1.14.2"
 set_md5 $nginx_filename "239b829a13cea1d244c1044e830bd9c2"
 set_dl $nginx_filename '
 http://nginx.org/download/nginx-1.14.2.tar.gz
-https://github.com/nginx/nginx/archive/release-1.14.2.tar.gz
 '
 
 #tengine设置

--- a/function/config.sh
+++ b/function/config.sh
@@ -103,14 +103,17 @@ set_md5 $boost_1_59_filename "51528a0e3b33d9e10aaa311d9eb451e3"
 set_dl $boost_1_59_filename '
 https://nchc.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz
 https://jaist.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz
+http://sourceforge.mirrorservice.org/b/bo/boost/boost/1.59.0/boost_1_59_0.tar.gz
 '
 
 boost_1_66_filename="boost_1_66_0"
 set_md5 $boost_1_66_filename "d275cd85b00022313c171f602db59fc5"
 set_dl $boost_1_66_filename '
 http://dl-cn.centos.bz/protect/10268950/ezhttp/boost_1_66_0.tar.gz
+https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
 http://dl-us.centos.bz/ezhttp/boost_1_66_0.tar.gz
 http://jaist.dl.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.gz
+http://sourceforge.mirrorservice.org/b/bo/boost/boost/1.66.0/boost_1_66_0.tar.gz
 '
 
 #php设置

--- a/function/config.sh
+++ b/function/config.sh
@@ -10,12 +10,10 @@ allow_seconds=3600
 ###################主要安装包设置###################
 
 #nginx设置
-nginx_filename="nginx-1.10.3"
-set_md5 $nginx_filename "204a20cb4f0b0c9db746c630d89ff4ea"
+nginx_filename="nginx-1.14.2"
+set_md5 $nginx_filename "239b829a13cea1d244c1044e830bd9c2"
 set_dl $nginx_filename '
-http://dl-cn.centos.bz/protect/10268950/ezhttp/nginx-1.10.3.tar.gz
-http://dl-us.centos.bz/ezhttp/nginx-1.10.3.tar.gz
-http://nginx.org/download/nginx-1.10.3.tar.gz
+http://nginx.org/download/nginx-1.14.2.tar.gz
 '
 
 #tengine设置
@@ -78,12 +76,10 @@ http://dl-us.centos.bz/ezhttp/mysql-5.6.35.tar.gz
 http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.35.tar.gz
 '
 
-mysql5_7_filename="mysql-5.7.17"
-set_md5 $mysql5_7_filename "db2a87ede6132b226f8d43d3ac349284"
+mysql5_7_filename="mysql-5.7.26"
+set_md5 $mysql5_7_filename "5756a63d37d343a39e8e2cf8b13378ba"
 set_dl $mysql5_7_filename '
-http://dl-cn.centos.bz/protect/10268950/ezhttp/mysql-5.7.17.tar.gz
-http://dl-us.centos.bz/ezhttp/mysql-5.7.17.tar.gz
-http://cdn.mysql.com/Downloads/MySQL-5.7/mysql-5.7.17.tar.gz
+http://cdn.mysql.com/Downloads/MySQL-5.7/mysql-5.7.26.tar.gz
 '
 set_hint $mysql5_7_filename "$mysql5_7_filename (need about 2GB RAM when building,try mysql-5.6 if failed)"
 

--- a/function/config.sh
+++ b/function/config.sh
@@ -162,6 +162,18 @@ http://dl-us.centos.bz/ezhttp/php-7.1.0.tar.gz
 http://us1.php.net/distributions/php-7.1.0.tar.gz
 '
 
+php7_2_filename="php-7.2.18"
+set_md5 $php7_2_filename "30333c28bbbbcc296cb80c0a9b059356"
+set_dl $php7_2_filename '
+https://www.php.net/distributions/php-7.2.18.tar.gz
+'
+
+php7_3_filename="php-7.3.5"
+set_md5 $php7_3_filename "8cca50c78c38ff2c92f9aa65a9c3894b"
+set_dl $php7_3_filename '
+https://www.php.net/distributions/php-7.3.5.tar.gz
+'
+
 #freetds设置
 freetds_filename="freetds-0.95.21"
 set_md5 $freetds_filename "90690b8f2f270151092009b71fe9b590"
@@ -859,7 +871,7 @@ nginx_modules_arr=(${lua_nginx_module_filename} ${nginx_concat_module_filename} 
             ${ngx_substitutions_filter_module_filename} ngx_stream_core_module ${nginx_upstream_check_module_filename} ${nginx_stream_upsync_module_filename} do_not_install)
 apache_arr=( ${apache2_2_filename} ${apache2_4_filename} custom_version do_not_install)
 mysql_arr=( ${mysql5_1_filename} ${mysql5_5_filename} ${mysql5_6_filename} ${mysql5_7_filename} ${mysql8_0_filename} libmysqlclient18 custom_version do_not_install)
-php_arr=( ${php5_2_filename} ${php5_3_filename} ${php5_4_filename} ${php5_5_filename} ${php5_6_filename} ${php7_1_filename} custom_version do_not_install)
+php_arr=( ${php5_2_filename} ${php5_3_filename} ${php5_4_filename} ${php5_5_filename} ${php5_6_filename} ${php7_1_filename} ${php7_2_filename} ${php7_3_filename} custom_version do_not_install)
 php_mode_arr=(with_apache  with_fastcgi)
 php_modules_arr=( ${ZendOptimizer_filename} ${ZendGuardLoader_filename} ${xcache_filename} ${eaccelerator_filename}
                  ${php_imagemagick_filename} ${ionCube_filename} ${php_memcache_filename} ${php_memcached_filename} ${php_redis_filename} 

--- a/function/config.sh
+++ b/function/config.sh
@@ -561,20 +561,6 @@ http://mirrors.ustc.edu.cn/gnu/patch/patch-2.7.tar.gz
 https://mirrors.tuna.tsinghua.edu.cn/gnu/patch/patch-2.7.tar.gz
 '
 
-#pkg-config设置
-pkg_config_filename="pkg-config-0.29.1"
-set_md5 $pkg_config_filename "f739a28cae4e0ca291f82d1d41ef107d"
-set_dl $pkg_config_filename '
-https://pkg-config.freedesktop.org/releases/pkg-config-0.29.1.tar.gz
-'
-
-#libzip设置
-libzip_filename="libzip-1.5.2"
-set_md5 $libzip_filename "8db7145801889ecf7ab481b23d6487cd"
-set_dl $libzip_filename '
-https://libzip.org/download/libzip-1.5.2.tar.gz
-'
-
 #libiconv设置
 libiconv_filename="libiconv-1.14"
 set_md5 $libiconv_filename "e34509b1623cec449dfeb73d7ce9c6c6"

--- a/function/config.sh
+++ b/function/config.sh
@@ -98,9 +98,16 @@ http://cdn.mysql.com/Downloads/MySQL-8.0/mysql-8.0.11.tar.gz
 
 # boost设置(mysql5.6依赖)
 
-boost_filename="boost_1_66_0"
-set_md5 $boost_filename "d275cd85b00022313c171f602db59fc5"
-set_dl $boost_filename '
+boost_1_59_filename="boost_1_59_0"
+set_md5 $boost_1_59_filename "51528a0e3b33d9e10aaa311d9eb451e3"
+set_dl $boost_1_59_filename '
+https://nchc.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz
+https://jaist.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz
+'
+
+boost_1_66_filename="boost_1_66_0"
+set_md5 $boost_1_66_filename "d275cd85b00022313c171f602db59fc5"
+set_dl $boost_1_66_filename '
 http://dl-cn.centos.bz/protect/10268950/ezhttp/boost_1_66_0.tar.gz
 http://dl-us.centos.bz/ezhttp/boost_1_66_0.tar.gz
 http://jaist.dl.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.gz

--- a/function/config.sh
+++ b/function/config.sh
@@ -14,6 +14,7 @@ nginx_filename="nginx-1.14.2"
 set_md5 $nginx_filename "239b829a13cea1d244c1044e830bd9c2"
 set_dl $nginx_filename '
 http://nginx.org/download/nginx-1.14.2.tar.gz
+https://github.com/nginx/nginx/archive/release-1.14.2.tar.gz
 '
 
 #tengine设置
@@ -55,40 +56,44 @@ http://mirror.reverse.net/pub/apache//httpd/httpd-2.4.25.tar.gz
 mysql5_1_filename="mysql-5.1.73"
 set_md5 $mysql5_1_filename "887f869bcc757957067b9198f707f32f"
 set_dl $mysql5_1_filename '
-http://dl-cn.centos.bz/protect/10268950/ezhttp/mysql-5.1.73.tar.gz
 http://dl-us.centos.bz/ezhttp/mysql-5.1.73.tar.gz
 http://cdn.mysql.com/Downloads/MySQL-5.1/mysql-5.1.73.tar.gz
+http://mirrors.cn99.com/mysql/Downloads/MySQL-5.1/mysql-5.1.73.tar.gz
+http://mirrors.ustc.edu.cn/mysql-ftp/Downloads/MySQL-5.1/mysql-5.1.73.tar.gz
 '
 
 mysql5_5_filename="mysql-5.5.54"
 set_md5 $mysql5_5_filename "358b596e62699397aeee3dfb469f5823"
 set_dl $mysql5_5_filename '
-http://dl-cn.centos.bz/protect/10268950/ezhttp/mysql-5.5.54.tar.gz
 http://dl-us.centos.bz/ezhttp/mysql-5.5.54.tar.gz
 http://cdn.mysql.com/Downloads/MySQL-5.5/mysql-5.5.54.tar.gz
+http://mirrors.cn99.com/mysql/Downloads/MySQL-5.5/mysql-5.5.54.tar.gz
+http://mirrors.ustc.edu.cn/mysql-ftp/Downloads/MySQL-5.5/mysql-5.5.54.tar.gz
 '
 
-mysql5_6_filename="mysql-5.6.35"
-set_md5 $mysql5_6_filename "e4f170f6f73aa94c0d8da90019545908"
+mysql5_6_filename="mysql-5.6.44"
+set_md5 $mysql5_6_filename "caa971e1d346bdb54e1b7470e88c6a9a"
 set_dl $mysql5_6_filename '
-http://dl-cn.centos.bz/protect/10268950/ezhttp/mysql-5.6.35.tar.gz
-http://dl-us.centos.bz/ezhttp/mysql-5.6.35.tar.gz
-http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.35.tar.gz
+http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.44.tar.gz
+http://mirrors.cn99.com/mysql/Downloads/MySQL-5.6/mysql-5.6.44.tar.gz
+http://mirrors.ustc.edu.cn/mysql-ftp/Downloads/MySQL-5.6/mysql-5.6.44.tar.gz
 '
 
 mysql5_7_filename="mysql-5.7.26"
 set_md5 $mysql5_7_filename "5756a63d37d343a39e8e2cf8b13378ba"
 set_dl $mysql5_7_filename '
 http://cdn.mysql.com/Downloads/MySQL-5.7/mysql-5.7.26.tar.gz
+http://mirrors.cn99.com/mysql/Downloads/MySQL-5.7/mysql-5.7.26.tar.gz
+http://mirrors.ustc.edu.cn/mysql-ftp/Downloads/MySQL-5.7/mysql-5.7.26.tar.gz
 '
 set_hint $mysql5_7_filename "$mysql5_7_filename (need about 2GB RAM when building,try mysql-5.6 if failed)"
 
-mysql8_0_filename="mysql-8.0.11"
+mysql8_0_filename="mysql-8.0.16"
 set_md5 $mysql8_0_filename "38d5a5c1a1eeed1129fec3a999aa5efd"
 set_dl $mysql8_0_filename '
-http://dl-cn.centos.bz/protect/10268950/ezhttp/mysql-8.0.11.tar.gz
-http://dl-us.centos.bz/ezhttp/mysql-8.0.11.tar.gz
-http://cdn.mysql.com/Downloads/MySQL-8.0/mysql-8.0.11.tar.gz
+http://cdn.mysql.com/Downloads/MySQL-8.0/mysql-8.0.16.tar.gz
+http://mirrors.cn99.com/mysql/Downloads/MySQL-8.0/mysql-8.0.16.tar.gz
+http://mirrors.ustc.edu.cn/mysql-ftp/Downloads/MySQL-8.0/mysql-8.0.16.tar.gz
 '
 
 
@@ -518,6 +523,8 @@ set_dl $ncurses_filename '
 http://dl-cn.centos.bz/protect/10268950/ezhttp/ncurses-5.8.tar.gz
 http://dl-us.centos.bz/ezhttp/ncurses-5.8.tar.gz
 http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.8.tar.gz
+http://mirrors.ustc.edu.cn/gnu/ncurses/ncurses-5.8.tar.gz
+https://mirrors.tuna.tsinghua.edu.cn/gnu/ncurses/ncurses-5.8.tar.gz
 '
 
 #ncurses设置(保持5.5版本,用于mysql5.1的安装)
@@ -527,6 +534,8 @@ set_dl $ncurses_filename2 '
 http://dl-cn.centos.bz/protect/10268950/ezhttp/ncurses-5.5.tar.gz
 http://dl-us.centos.bz/ezhttp/ncurses-5.5.tar.gz
 http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.5.tar.gz
+http://mirrors.ustc.edu.cn/gnu/ncurses/ncurses/ncurses-5.5.tar.gz
+https://mirrors.tuna.tsinghua.edu.cn/gnu/bison/ncurses/ncurses-5.5.tar.gz
 '
 
 #bison设置
@@ -536,6 +545,9 @@ set_dl $bison_filename '
 http://dl-cn.centos.bz/protect/10268950/ezhttp/bison-2.7.tar.gz
 http://dl-us.centos.bz/ezhttp/bison-2.7.tar.gz
 http://ftp.gnu.org/gnu/bison/bison-2.7.tar.gz
+http://mirrors.ustc.edu.cn/gnu/bison/bison-2.7.tar.gz
+https://mirrors.tuna.tsinghua.edu.cn/gnu/bison/bison-2.7.tar.gz
+
 '
 
 #patch设置
@@ -545,15 +557,32 @@ set_dl $patch_filename '
 http://dl-cn.centos.bz/protect/10268950/ezhttp/patch-2.7.tar.gz
 http://dl-us.centos.bz/ezhttp/patch-2.7.tar.gz
 http://ftp.gnu.org/gnu/patch/patch-2.7.tar.gz
+http://mirrors.ustc.edu.cn/gnu/patch/patch-2.7.tar.gz
+https://mirrors.tuna.tsinghua.edu.cn/gnu/patch/patch-2.7.tar.gz
+'
+
+#pkg-config设置
+pkg_config_filename="pkg-config-0.29.1"
+set_md5 $pkg_config_filename "f739a28cae4e0ca291f82d1d41ef107d"
+set_dl $pkg_config_filename '
+https://pkg-config.freedesktop.org/releases/pkg-config-0.29.1.tar.gz
+'
+
+#libzip设置
+libzip_filename="libzip-1.5.2"
+set_md5 $libzip_filename "8db7145801889ecf7ab481b23d6487cd"
+set_dl $libzip_filename '
+https://libzip.org/download/libzip-1.5.2.tar.gz
 '
 
 #libiconv设置
 libiconv_filename="libiconv-1.14"
 set_md5 $libiconv_filename "e34509b1623cec449dfeb73d7ce9c6c6"
 set_dl $libiconv_filename '
-http://dl-cn.centos.bz/protect/10268950/ezhttp/libiconv-1.14.tar.gz
 http://dl-us.centos.bz/ezhttp/libiconv-1.14.tar.gz
 http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz
+http://mirrors.ustc.edu.cn/gnu/libiconv/libiconv-1.14.tar.gz
+https://mirrors.tuna.tsinghua.edu.cn/gnu/libiconv/libiconv-1.14.tar.gz
 '
 
 
@@ -564,6 +593,8 @@ set_dl $autoconf_filename '
 http://dl-cn.centos.bz/protect/10268950/ezhttp/autoconf-2.59.tar.gz
 http://dl-us.centos.bz/ezhttp/autoconf-2.59.tar.gz
 http://ftp.gnu.org/gnu/autoconf/autoconf-2.59.tar.gz
+http://mirrors.ustc.edu.cn/gnu/autoconf/autoconf-2.59.tar.gz
+https://mirrors.tuna.tsinghua.edu.cn/gnu/autoconf/autoconf-2.59.tar.gz
 '
 
 #libxml2设置(保持2-2.8.0版本)

--- a/function/depends.sh
+++ b/function/depends.sh
@@ -43,7 +43,7 @@ install_php_depends(){
 			check_installed "install_mhash " "${depends_prefix}/${mhash_filename}"
 			check_installed "install_libmcrypt" "${depends_prefix}/${libmcrypt_filename}"
 		fi
-		
+		check_installed "install_libzip" "${depends_prefix}/${libzip_filename}"
 	else
 		check_installed "install_m4" "${depends_prefix}/${m4_filename}"
 		check_installed "install_autoconf" "${depends_prefix}/${autoconf_filename}"

--- a/function/depends.sh
+++ b/function/depends.sh
@@ -5,7 +5,7 @@ install_php_depends(){
 	
 	#安装依赖
 	if check_sys packageManager apt;then
-		local packages=(m4 autoconf libcurl4-gnutls-dev autoconf2.13 libxml2-dev openssl zlib1g-dev libpcre3-dev libtool libjpeg-dev libpng12-dev libfreetype6-dev libmhash-dev libmcrypt-dev libssl-dev pkg-config libzip)
+		local packages=(m4 autoconf libcurl4-gnutls-dev autoconf2.13 libxml2-dev openssl zlib1g-dev libpcre3-dev libtool libjpeg-dev libpng12-dev libfreetype6-dev libmhash-dev libmcrypt-dev libssl-dev pkg-config libzip-dev)
 		for p in ${packages[@]}
 		do
 			apt-get -y install $p
@@ -18,7 +18,7 @@ install_php_depends(){
 		create_lib_link "libiconv.so.2"
 		create_lib_link "libssl.so"
 	elif check_sys packageManager yum;then
-		yum -y install m4 autoconf libxml2-devel openssl openssl-devel zlib-devel curl-devel pcre-devel libtool-libs libtool-ltdl-devel libjpeg-devel libpng-devel freetype-devel mhash-devel libmcrypt-devel pkg-config libzip
+		yum -y install m4 autoconf libxml2-devel openssl openssl-devel zlib-devel curl-devel pcre-devel libtool-libs libtool-ltdl-devel libjpeg-devel libpng-devel freetype-devel mhash-devel libmcrypt-devel pkg-config libzip-devel
 		create_lib_link "libjpeg.so"
 		create_lib_link "libpng.so"
 		create_lib_link "libltdl.so"

--- a/function/depends.sh
+++ b/function/depends.sh
@@ -5,7 +5,7 @@ install_php_depends(){
 	
 	#安装依赖
 	if check_sys packageManager apt;then
-		local packages=(m4 autoconf libcurl4-gnutls-dev  autoconf2.13 libxml2-dev openssl zlib1g-dev libpcre3-dev libtool libjpeg-dev libpng12-dev libfreetype6-dev libmhash-dev libmcrypt-dev libssl-dev)
+		local packages=(m4 autoconf libcurl4-gnutls-dev autoconf2.13 libxml2-dev openssl zlib1g-dev libpcre3-dev libtool libjpeg-dev libpng12-dev libfreetype6-dev libmhash-dev libmcrypt-dev libssl-dev pkg-config libzip)
 		for p in ${packages[@]}
 		do
 			apt-get -y install $p
@@ -18,7 +18,7 @@ install_php_depends(){
 		create_lib_link "libiconv.so.2"
 		create_lib_link "libssl.so"
 	elif check_sys packageManager yum;then
-		yum -y install m4 autoconf libxml2-devel openssl openssl-devel  zlib-devel curl-devel pcre-devel libtool-libs libtool-ltdl-devel libjpeg-devel libpng-devel freetype-devel mhash-devel libmcrypt-devel
+		yum -y install m4 autoconf libxml2-devel openssl openssl-devel zlib-devel curl-devel pcre-devel libtool-libs libtool-ltdl-devel libjpeg-devel libpng-devel freetype-devel mhash-devel libmcrypt-devel pkg-config libzip
 		create_lib_link "libjpeg.so"
 		create_lib_link "libpng.so"
 		create_lib_link "libltdl.so"

--- a/function/depends.sh
+++ b/function/depends.sh
@@ -18,7 +18,7 @@ install_php_depends(){
 		create_lib_link "libiconv.so.2"
 		create_lib_link "libssl.so"
 	elif check_sys packageManager yum;then
-		yum -y install m4 autoconf libxml2-devel openssl openssl-devel zlib-devel curl-devel pcre-devel libtool-libs libtool-ltdl-devel libjpeg-devel libpng-devel freetype-devel mhash-devel libmcrypt-devel pkg-config libzip-devel
+		yum -y install m4 autoconf libxml2-devel openssl openssl-devel zlib-devel curl-devel pcre-devel libtool-libs libtool-ltdl-devel libjpeg-devel libpng-devel freetype-devel mhash-devel libmcrypt-devel pkg-config libicu-devel
 		create_lib_link "libjpeg.so"
 		create_lib_link "libpng.so"
 		create_lib_link "libltdl.so"
@@ -86,6 +86,15 @@ install_patch(){
 	error_detect "parallel_make"
 	error_detect "make install"
 	add_to_env "${depends_prefix}/${patch_filename}"
+}
+
+install_libzip(){
+	download_file  "${libzip_filename}.tar.gz"
+	cd $cur_dir/soft/
+	tar xzvf ${libzip_filename}.tar.gz
+	cd ${libzip_filename}
+	./configure --prefix=${depends_prefix}/${libzip_filename}
+	make && make install
 }
 
 #安装libiconv

--- a/function/mysql.sh
+++ b/function/mysql.sh
@@ -116,14 +116,14 @@ if [ "$mysql" != "do_not_install" ];then
 				else
 					other_option="-DCURSES_LIBRARY=${depends_prefix}/${ncurses_filename}/lib/libncurses.a  -DCURSES_INCLUDE_PATH=${depends_prefix}/${ncurses_filename}/include/"
 				fi
-				mysql_configure_args="-DCMAKE_INSTALL_PREFIX=${mysql_location} -DWITH_BOOST=$cur_dir/soft/${boost_filename}  -DSYSCONFDIR=${mysql_location}/etc -DMYSQL_UNIX_ADDR=${mysql_data_location}/mysql.sock -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci -DWITH_EXTRA_CHARSETS=complex -DWITH_EMBEDDED_SERVER=1 -DENABLED_LOCAL_INFILE=1 $other_option"
+				mysql_configure_args="-DCMAKE_INSTALL_PREFIX=${mysql_location} -DWITH_BOOST=$cur_dir/soft/${boost_1_59_filename}  -DSYSCONFDIR=${mysql_location}/etc -DMYSQL_UNIX_ADDR=${mysql_data_location}/mysql.sock -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci -DWITH_EXTRA_CHARSETS=complex -DWITH_EMBEDDED_SERVER=1 -DENABLED_LOCAL_INFILE=1 $other_option"
 			elif [ "$mysql" == "${mysql8_0_filename}" ];then
 				if check_sys packageSupport;then
 					other_option=""
 				else
 					other_option="-DCURSES_LIBRARY=${depends_prefix}/${ncurses_filename}/lib/libncurses.a  -DCURSES_INCLUDE_PATH=${depends_prefix}/${ncurses_filename}/include/"
 				fi
-				mysql_configure_args="-DCMAKE_INSTALL_PREFIX=${mysql_location} -DWITH_BOOST=$cur_dir/soft/${boost_filename}  -DSYSCONFDIR=${mysql_location}/etc -DMYSQL_UNIX_ADDR=${mysql_data_location}/mysql.sock -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci -DWITH_EXTRA_CHARSETS=complex -DWITH_EMBEDDED_SERVER=1 -DENABLED_LOCAL_INFILE=1 $other_option"
+				mysql_configure_args="-DCMAKE_INSTALL_PREFIX=${mysql_location} -DWITH_BOOST=$cur_dir/soft/${boost_1_66_filename}  -DSYSCONFDIR=${mysql_location}/etc -DMYSQL_UNIX_ADDR=${mysql_data_location}/mysql.sock -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci -DWITH_EXTRA_CHARSETS=complex -DWITH_EMBEDDED_SERVER=1 -DENABLED_LOCAL_INFILE=1 $other_option"
 
 			fi
 
@@ -167,7 +167,7 @@ if [ "$mysql" != "do_not_install" ];then
 			else
 				other_option="-DCURSES_LIBRARY=${depends_prefix}/${ncurses_filename}/lib/libncurses.a  -DCURSES_INCLUDE_PATH=${depends_prefix}/${ncurses_filename}/include/ -DWITH_SSL=${depends_prefix}/${openssl_filename}"
 			fi
-			mysql_configure_args="-DCMAKE_INSTALL_PREFIX=${mysql_location} -DWITH_BOOST=$cur_dir/soft/${boost_filename} -DSYSCONFDIR=${mysql_location}/etc -DMYSQL_UNIX_ADDR=/tmp/mysql.sock -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci -DWITH_EXTRA_CHARSETS=complex -DWITH_EMBEDDED_SERVER=1 -DENABLED_LOCAL_INFILE=1  $other_option"		
+			mysql_configure_args="-DCMAKE_INSTALL_PREFIX=${mysql_location} -DWITH_BOOST=$cur_dir/soft/${boost_1_59_filename} -DSYSCONFDIR=${mysql_location}/etc -DMYSQL_UNIX_ADDR=/tmp/mysql.sock -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci -DWITH_EXTRA_CHARSETS=complex -DWITH_EMBEDDED_SERVER=1 -DENABLED_LOCAL_INFILE=1  $other_option"		
 		fi
 	fi	
 fi	
@@ -269,10 +269,10 @@ install_mysqld(){
 		fi
 
 		# 下载boost
-		download_file "${boost_filename}.tar.gz"
+		download_file "${boost_1_59_filename}.tar.gz"
 		cd $cur_dir/soft/
-		rm -rf ${boost_filename}
-		tar xzvf ${boost_filename}.tar.gz
+		rm -rf ${boost_1_59_filename}
+		tar xzvf ${boost_1_59_filename}.tar.gz
 
 		download_file  "${mysql5_7_filename}.tar.gz"	
 		cd $cur_dir/soft/
@@ -300,10 +300,10 @@ install_mysqld(){
 		fi
 
 		# 下载boost
-		download_file "${boost_filename}.tar.gz"
+		download_file "${boost_1_66_filename}.tar.gz"
 		cd $cur_dir/soft/
-		rm -rf ${boost_filename}
-		tar xzvf ${boost_filename}.tar.gz
+		rm -rf ${boost_1_66_filename}
+		tar xzvf ${boost_1_66_filename}.tar.gz
 
 		download_file  "${mysql8_0_filename}.tar.gz"	
 		cd $cur_dir/soft/

--- a/function/mysql.sh
+++ b/function/mysql.sh
@@ -257,9 +257,9 @@ install_mysqld(){
 	elif [ "$mysql" == "${mysql5_7_filename}" ];then
 		#安装依赖
 		if check_sys packageManager apt;then
-			apt-get -y install libncurses5-dev cmake m4 bison libssl-dev
+			apt-get -y install libncurses5-dev cmake m4 bison libssl-dev pkg-config
 		elif check_sys packageManager yum;then
-			yum -y install ncurses-devel cmake m4 bison openssl-devel
+			yum -y install ncurses-devel cmake m4 bison openssl-devel pkg-config
 		else
 			check_installed "install_ncurses" "${depends_prefix}/${ncurses_filename}"
 			check_installed "install_cmake" "${depends_prefix}/${cmake_filename}"

--- a/function/nginx.sh
+++ b/function/nginx.sh
@@ -59,11 +59,11 @@ nginx_preinstall_settings(){
 		if [ "$nginx" != "do_not_install" ];then
 			#定义nginx编译参数
 			if [ "$nginx" == "${nginx_filename}" ];then
-				nginx_configure_args="--prefix=${nginx_location} --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename}  --with-http_sub_module --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module"
+				nginx_configure_args="--prefix=${nginx_location} --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename}  --with-http_sub_module --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module --with-http_v2_module"
 			elif [ "$nginx" == "${tengine_filename}" ];then
-				nginx_configure_args="--prefix=${nginx_location} --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module --with-http_concat_module --with-http_sysguard_module --with-http_upstream_check_module"
+				nginx_configure_args="--prefix=${nginx_location} --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module --with-http_concat_module --with-http_sysguard_module --with-http_upstream_check_module --with-http_v2_module"
 			elif [ "$nginx" == "${openresty_filename}" ];then
-				nginx_configure_args="--prefix=${nginx_location} --with-luajit --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module"
+				nginx_configure_args="--prefix=${nginx_location} --with-luajit --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module --with-http_v2_module"
 			fi
 
 			#提示是否更改编译参数

--- a/function/php-modules.sh
+++ b/function/php-modules.sh
@@ -25,7 +25,11 @@ php_modules_preinstall_settings(){
 					elif [[ `get_php_version $phpConfig` == "5.6" ]]; then
 						php=${php5_6_filename}
 					elif [[ `get_php_version $phpConfig` == "7.1" ]]; then
-						php=${php7_1_filename}												
+						php=${php7_1_filename}
+					elif [[ `get_php_version $phpConfig` == "7.2" ]]; then
+						php=${php7_2_filename}
+					elif [[ `get_php_version $phpConfig` == "7.3" ]]; then
+						php=${php7_3_filename}
 					else
 						echo "sorry,unsupported php version."
 						exit 1
@@ -78,6 +82,34 @@ php_modules_preinstall_settings(){
 			php_modules_arr=(${php_modules_arr[@]#${ZendGuardLoader_filename}})
 			php_modules_arr=(${php_modules_arr[@]#${ionCube_filename}})
 		elif [ "$php" == "${php7_1_filename}" ];then
+			#从数组中删除ZendOptimizer、eaccelerator、xcache ionCube_filename
+			php_modules_arr=(${php_modules_arr[@]#${ZendOptimizer_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${eaccelerator_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${xcache_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${ZendGuardLoader_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${ionCube_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_imagemagick_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_memcache_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_memcached_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_redis_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_mongo_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${xdebug_filename}})
+			php_modules_arr=(${php_modules_arr[@]#mssql})
+		elif [ "$php" == "${php7_2_filename}" ];then
+			#从数组中删除ZendOptimizer、eaccelerator、xcache ionCube_filename
+			php_modules_arr=(${php_modules_arr[@]#${ZendOptimizer_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${eaccelerator_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${xcache_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${ZendGuardLoader_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${ionCube_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_imagemagick_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_memcache_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_memcached_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_redis_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${php_mongo_filename}})
+			php_modules_arr=(${php_modules_arr[@]#${xdebug_filename}})
+			php_modules_arr=(${php_modules_arr[@]#mssql})
+		elif [ "$php" == "${php7_3_filename}" ];then
 			#从数组中删除ZendOptimizer、eaccelerator、xcache ionCube_filename
 			php_modules_arr=(${php_modules_arr[@]#${ZendOptimizer_filename}})
 			php_modules_arr=(${php_modules_arr[@]#${eaccelerator_filename}})

--- a/function/php.sh
+++ b/function/php.sh
@@ -167,6 +167,17 @@ php_preinstall_settings(){
                 if [[ "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" || "$php" == "${php7_2_filename}" || "$php" == "${php7_3_filename}" ]]; then
                     other_option="${other_option} --enable-opcache"
                 fi
+                #  >= PHP 5.6 在CentOS 6/7中重新编译libzip
+
+                if [[ "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" || "$php" == "${php7_2_filename}" || "$php" == "${php7_3_filename}" ]]; then
+
+                    if check_sys packageManager yum; then
+                        yum remove libzip
+                        check_installed "install_libzip" "${depends_prefix}/${libzip_filename}"
+                        other_option="${other_option} --with-libzip=${depends_prefix}/${libzip_filename}"
+                    fi
+                fi
+
                 php_configure_args="--prefix=$php_location  --with-config-file-path=${php_location}/etc  ${php_run_php_mode}  --enable-bcmath=shared  --with-pdo_sqlite  --with-gettext=shared  --with-iconv --enable-ftp=shared  --with-sqlite  --with-sqlite3  --enable-mbstring=shared  --enable-sockets=shared  --enable-zip   --enable-soap=shared  $other_option   ${with_mysqlnd}  --without-pear  $lib64  --disable-fileinfo --enable-bcmath --enable-intl --with-bz2"
             fi  
 

--- a/function/php.sh
+++ b/function/php.sh
@@ -441,7 +441,47 @@ if [ "$php_mode" == "with_fastcgi" ];then
         set_php_variable request_order  "CGP"
         set_php_variable cgi.fix_pathinfo 0
         set_php_variable short_open_tag on
-        set_php_variable date.timezone Asia/Chongqing
+        set_php_variable date.timezone Asia/Shanghai
+
+        #开启slow log
+        sed -i 's#;slowlog = log/$pool.log.slow#slowlog = var/log/$pool.log.slow#' $php_location/etc/php-fpm.d/www.conf
+        sed -i 's/;request_slowlog_timeout = 0/request_slowlog_timeout = 5/' $php_location/etc/php-fpm.d/www.conf       
+
+    fi
+    elif [[ "$php" == "${php7_2_filename}" ]]; then
+        \cp $cur_dir/soft/${php}/sapi/fpm/init.d.php-fpm /etc/init.d/php-fpm
+        chmod +x /etc/init.d/php-fpm
+        \cp $php_location/etc/php-fpm.d/www.conf.default $php_location/etc/php-fpm.d/www.conf
+        sed -i 's/^user =.*/user = www/' $php_location/etc/php-fpm.d/www.conf
+        sed -i 's/^group =.*/group = www/' $php_location/etc/php-fpm.d/www.conf
+
+        set_php_variable disable_functions "dl,eval,assert,exec,popen,system,passthru,shell_exec,escapeshellarg,escapeshellcmd,proc_close,proc_open"
+        set_php_variable expose_php Off
+        set_php_variable error_log  ${php_location}/var/log/php_errors.log
+        set_php_variable request_order  "CGP"
+        set_php_variable cgi.fix_pathinfo 0
+        set_php_variable short_open_tag on
+        set_php_variable date.timezone Asia/Shanghai
+
+        #开启slow log
+        sed -i 's#;slowlog = log/$pool.log.slow#slowlog = var/log/$pool.log.slow#' $php_location/etc/php-fpm.d/www.conf
+        sed -i 's/;request_slowlog_timeout = 0/request_slowlog_timeout = 5/' $php_location/etc/php-fpm.d/www.conf       
+
+    fi
+    elif [[ "$php" == "${php7_3_filename}" ]]; then
+        \cp $cur_dir/soft/${php}/sapi/fpm/init.d.php-fpm /etc/init.d/php-fpm
+        chmod +x /etc/init.d/php-fpm
+        \cp $php_location/etc/php-fpm.d/www.conf.default $php_location/etc/php-fpm.d/www.conf
+        sed -i 's/^user =.*/user = www/' $php_location/etc/php-fpm.d/www.conf
+        sed -i 's/^group =.*/group = www/' $php_location/etc/php-fpm.d/www.conf
+
+        set_php_variable disable_functions "dl,eval,assert,exec,popen,system,passthru,shell_exec,escapeshellarg,escapeshellcmd,proc_close,proc_open"
+        set_php_variable expose_php Off
+        set_php_variable error_log  ${php_location}/var/log/php_errors.log
+        set_php_variable request_order  "CGP"
+        set_php_variable cgi.fix_pathinfo 0
+        set_php_variable short_open_tag on
+        set_php_variable date.timezone Asia/Shanghai
 
         #开启slow log
         sed -i 's#;slowlog = log/$pool.log.slow#slowlog = var/log/$pool.log.slow#' $php_location/etc/php-fpm.d/www.conf

--- a/function/php.sh
+++ b/function/php.sh
@@ -164,7 +164,7 @@ php_preinstall_settings(){
                 fi
 
                 # 5.5 5.6开启opcache
-                if [[ "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" || "$php" == "${php7_2_filename}" || "$php" == "${php7_3_filename}"]]; then
+                if [[ "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" || "$php" == "${php7_2_filename}" || "$php" == "${php7_3_filename}" ]]; then
                     other_option="${other_option} --enable-opcache"
                 fi
                 php_configure_args="--prefix=$php_location  --with-config-file-path=${php_location}/etc  ${php_run_php_mode}  --enable-bcmath=shared  --with-pdo_sqlite  --with-gettext=shared  --with-iconv --enable-ftp=shared  --with-sqlite  --with-sqlite3  --enable-mbstring=shared  --enable-sockets=shared  --enable-zip   --enable-soap=shared  $other_option   ${with_mysqlnd}  --without-pear  $lib64  --disable-fileinfo --enable-bcmath --enable-intl --with-bz2"

--- a/function/php.sh
+++ b/function/php.sh
@@ -167,13 +167,13 @@ php_preinstall_settings(){
                 if [[ "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" || "$php" == "${php7_2_filename}" || "$php" == "${php7_3_filename}" ]]; then
                     other_option="${other_option} --enable-opcache"
                 fi
+
                 #  >= PHP 5.6 在CentOS 6/7中重新编译libzip
 
                 if [[ "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" || "$php" == "${php7_2_filename}" || "$php" == "${php7_3_filename}" ]]; then
 
                     if check_sys packageManager yum; then
                         yum remove libzip
-                        check_installed "install_libzip" "${depends_prefix}/${libzip_filename}"
                         other_option="${other_option} --with-libzip=${depends_prefix}/${libzip_filename}"
                     fi
                 fi

--- a/function/php.sh
+++ b/function/php.sh
@@ -447,7 +447,6 @@ if [ "$php_mode" == "with_fastcgi" ];then
         sed -i 's#;slowlog = log/$pool.log.slow#slowlog = var/log/$pool.log.slow#' $php_location/etc/php-fpm.d/www.conf
         sed -i 's/;request_slowlog_timeout = 0/request_slowlog_timeout = 5/' $php_location/etc/php-fpm.d/www.conf       
 
-    fi
     elif [[ "$php" == "${php7_2_filename}" ]]; then
         \cp $cur_dir/soft/${php}/sapi/fpm/init.d.php-fpm /etc/init.d/php-fpm
         chmod +x /etc/init.d/php-fpm
@@ -467,7 +466,6 @@ if [ "$php_mode" == "with_fastcgi" ];then
         sed -i 's#;slowlog = log/$pool.log.slow#slowlog = var/log/$pool.log.slow#' $php_location/etc/php-fpm.d/www.conf
         sed -i 's/;request_slowlog_timeout = 0/request_slowlog_timeout = 5/' $php_location/etc/php-fpm.d/www.conf       
 
-    fi
     elif [[ "$php" == "${php7_3_filename}" ]]; then
         \cp $cur_dir/soft/${php}/sapi/fpm/init.d.php-fpm /etc/init.d/php-fpm
         chmod +x /etc/init.d/php-fpm

--- a/function/php.sh
+++ b/function/php.sh
@@ -48,7 +48,21 @@ php_preinstall_settings(){
                 read -p "please input $php download url(must be tar.gz file format): " link
                 set_dl $version "$link"
                 custom_info="$custom_info\nphp7_1_filename=$version\n$(get_dl_valname $version)=$link)\n"
-                break                       
+                break
+            elif echo "$version" | grep -q -E '^php-7\.2\.[0-9]+$';then
+                php7_2_filename=$version
+                php=$version
+                read -p "please input $php download url(must be tar.gz file format): " link
+                set_dl $version "$link"
+                custom_info="$custom_info\nphp7_2_filename=$version\n$(get_dl_valname $version)=$link)\n"
+                break
+            elif echo "$version" | grep -q -E '^php-7\.3\.[0-9]+$';then
+                php7_3_filename=$version
+                php=$version
+                read -p "please input $php download url(must be tar.gz file format): " link
+                set_dl $version "$link"
+                custom_info="$custom_info\nphp7_3_filename=$version\n$(get_dl_valname $version)=$link)\n"
+                break
             else
                 echo "version invalid,please reinput."
             fi
@@ -128,7 +142,7 @@ php_preinstall_settings(){
                 #php编译参数
                 php_configure_args="--prefix=$php_location  --with-config-file-path=${php_location}/etc  ${php_run_php_mode}  --with-gettext=shared  --with-sqlite  --with-pdo_sqlite  --enable-bcmath=shared  --enable-ftp=shared  --enable-mbstring=shared  --with-iconv  --enable-sockets=shared  --enable-zip  --enable-soap=shared  $other_option  ${with_mysql}  --without-pear  $lib64"
 
-            elif [[ "$php" == "${php5_3_filename}" || "$php" == "${php5_4_filename}" || "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" ]];then
+            elif [[ "$php" == "${php5_3_filename}" || "$php" == "${php5_4_filename}" || "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" || "$php" == "${php7_2_filename}" || "$php" == "${php7_3_filename}" ]];then
 
                 #判断php运行模式
                 if [ "$php_mode" == "with_apache" ];then
@@ -150,10 +164,10 @@ php_preinstall_settings(){
                 fi
 
                 # 5.5 5.6开启opcache
-                if [[ "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" ]]; then
+                if [[ "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" || "$php" == "${php7_2_filename}" || "$php" == "${php7_3_filename}"]]; then
                     other_option="${other_option} --enable-opcache"
                 fi
-                php_configure_args="--prefix=$php_location  --with-config-file-path=${php_location}/etc  ${php_run_php_mode}  --enable-bcmath=shared  --with-pdo_sqlite  --with-gettext=shared  --with-iconv --enable-ftp=shared  --with-sqlite  --with-sqlite3  --enable-mbstring=shared  --enable-sockets=shared  --enable-zip   --enable-soap=shared  $other_option   ${with_mysqlnd}  --without-pear  $lib64  --disable-fileinfo"
+                php_configure_args="--prefix=$php_location  --with-config-file-path=${php_location}/etc  ${php_run_php_mode}  --enable-bcmath=shared  --with-pdo_sqlite  --with-gettext=shared  --with-iconv --enable-ftp=shared  --with-sqlite  --with-sqlite3  --enable-mbstring=shared  --enable-sockets=shared  --enable-zip   --enable-soap=shared  $other_option   ${with_mysqlnd}  --without-pear  $lib64  --disable-fileinfo --enable-bcmath --enable-intl --with-bz2"
             fi  
 
 
@@ -330,6 +344,36 @@ install_php(){
         mkdir -p ${php_location}/etc
         \cp  php.ini-production $php_location/etc/php.ini
         [ "$php_mode" == "with_fastcgi" ] && \cp  $php_location/etc/php-fpm.conf.default $php_location/etc/php-fpm.conf 
+    
+    elif [ "$php" == "${php7_2_filename}" ];then
+        download_file  "${php7_2_filename}.tar.gz"
+        cd $cur_dir/soft/
+        tar xzvf ${php7_2_filename}.tar.gz
+        cd ${php7_2_filename}
+        make clean
+        error_detect "./configure ${php_configure_args}"
+        error_detect "parallel_make ZEND_EXTRA_LIBS='-liconv'"
+        error_detect "make install" 
+        
+        #配置php
+        mkdir -p ${php_location}/etc
+        \cp  php.ini-production $php_location/etc/php.ini
+        [ "$php_mode" == "with_fastcgi" ] && \cp  $php_location/etc/php-fpm.conf.default $php_location/etc/php-fpm.conf
+    
+    elif [ "$php" == "${php7_3_filename}" ];then
+        download_file  "${php7_3_filename}.tar.gz"
+        cd $cur_dir/soft/
+        tar xzvf ${php7_3_filename}.tar.gz
+        cd ${php7_3_filename}
+        make clean
+        error_detect "./configure ${php_configure_args}"
+        error_detect "parallel_make ZEND_EXTRA_LIBS='-liconv'"
+        error_detect "make install" 
+        
+        #配置php
+        mkdir -p ${php_location}/etc
+        \cp  php.ini-production $php_location/etc/php.ini
+        [ "$php_mode" == "with_fastcgi" ] && \cp  $php_location/etc/php-fpm.conf.default $php_location/etc/php-fpm.conf
     fi
 
     #记录php安装位置
@@ -407,7 +451,7 @@ if [ "$php_mode" == "with_fastcgi" ];then
     # 设置php_errors目录权限
     chown www ${php_location}/var/log/
     # 启用opcache
-    if [[ "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" ]];then
+    if [[ "$php" == "${php5_5_filename}" || "$php" == "${php5_6_filename}" || "$php" == "${php7_1_filename}" || "$php" == "${php7_2_filename}" || "$php" == "${php7_3_filename}" ]];then
         cat >> $php_location/etc/php.ini <<EOF
 [opcache]
 zend_extension=opcache.so

--- a/function/public.sh
+++ b/function/public.sh
@@ -655,13 +655,13 @@ ask_not_null_var(){
 
 }
 
-#安装编译工具
+#安装编译工具 （同时安装bzip2开发包，提供PHP开启bz2函数的依赖）
 install_tool(){ 
 	if check_sys packageManager apt;then
 		apt-get -y update
-		apt-get -y install gcc g++ make wget perl curl bzip2 patch
+		apt-get -y install gcc g++ make wget perl curl bzip2 libbz2-dev patch
 	elif check_sys packageManager yum; then
-		yum -y install gcc gcc-c++ make wget perl  curl bzip2 which patch
+		yum -y install gcc gcc-c++ make wget perl  curl bzip2 bzip2-devel which patch
 	fi
 
 	check_command_exist "gcc"

--- a/function/upgrade.sh
+++ b/function/upgrade.sh
@@ -44,7 +44,7 @@ Upgrade_nginx_tengine_openresty(){
 		elif echo "$nginx_new_version" | grep -q -E '^ngx_openresty-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$';then
 			set_official_link_val $nginx_new_version "http://openresty.org/download/${nginx_new_version}.tar.gz"
 			nginx_location=$(echo $nginx_location | sed -r 's#nginx/?$##')
-			nginx_configure_args="--prefix=${nginx_location} --with-luajit --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module"
+			nginx_configure_args="--prefix=${nginx_location} --with-luajit --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module --with-http_v2_module"
 			break
 		else
 			echo "$nginx_new_version invalid,please reinput."

--- a/start.sh
+++ b/start.sh
@@ -398,7 +398,7 @@ setup_by_cmdline(){
                 other_option="-DCURSES_LIBRARY=${depends_prefix}/${ncurses_filename}/lib/libncurses.a  -DCURSES_INCLUDE_PATH=${depends_prefix}/${ncurses_filename}/include/"
             fi
             mysql=${mysql5_7_filename}
-            mysql_configure_args="-DCMAKE_INSTALL_PREFIX=${mysql_location} -DWITH_BOOST=$cur_dir/soft/${boost_filename}  -DSYSCONFDIR=${mysql_location}/etc -DMYSQL_UNIX_ADDR=${mysql_data_location}/mysql.sock -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci -DWITH_EXTRA_CHARSETS=complex -DWITH_EMBEDDED_SERVER=1 -DENABLED_LOCAL_INFILE=1 $other_option"
+            mysql_configure_args="-DCMAKE_INSTALL_PREFIX=${mysql_location} -DWITH_BOOST=$cur_dir/soft/${boost_1_59_filename}  -DSYSCONFDIR=${mysql_location}/etc -DMYSQL_UNIX_ADDR=${mysql_data_location}/mysql.sock -DDEFAULT_CHARSET=utf8 -DDEFAULT_COLLATION=utf8_general_ci -DWITH_EXTRA_CHARSETS=complex -DWITH_EMBEDDED_SERVER=1 -DENABLED_LOCAL_INFILE=1 $other_option"
         fi        
 
     else

--- a/start.sh
+++ b/start.sh
@@ -218,15 +218,15 @@ setup_by_cmdline(){
         # 设置编译参数
         if if_in_array nginx "$package";then
             nginx=${nginx_filename}
-            nginx_configure_args="--prefix=${nginx_location} --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename}  --with-http_sub_module --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module"
+            nginx_configure_args="--prefix=${nginx_location} --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename}  --with-http_sub_module --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module --with-http_v2_module"
 
         elif if_in_array tengine "$package";then
             nginx=${tengine_filename}
-            nginx_configure_args="--prefix=${nginx_location} --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module --with-http_concat_module --with-http_sysguard_module --with-http_upstream_check_module"
+            nginx_configure_args="--prefix=${nginx_location} --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module --with-http_concat_module --with-http_sysguard_module --with-http_upstream_check_module --with-http_v2_module"
 
         elif if_in_array openresty "$package";then
             nginx=${openresty_filename}
-            nginx_configure_args="--prefix=${nginx_location} --with-luajit --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module"
+            nginx_configure_args="--prefix=${nginx_location} --with-luajit --with-http_ssl_module --with-openssl=$cur_dir/soft/${openssl_filename} --with-http_realip_module  --with-http_stub_status_module --with-pcre-jit --with-pcre --with-pcre=$cur_dir/soft/${pcre_filename} --with-zlib=$cur_dir/soft/${zlib_filename} --with-http_secure_link_module --with-http_v2_module"
 
         else
             nginx=do_not_install


### PR DESCRIPTION
在安装 MySQL 5.7 时，提示MySQL 5.7 版本依赖 boost 1.59.0 而不是 boost 1.66.0 ，我在 config.sh 中增加了 boost 版本，并在 mysql.sh 和 start.sh 中判断不同版本的 MySQL 中 选则相应的 boost 版本。